### PR TITLE
Added multi-threading to X16R CPU-Fallback hashing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ccminer
 
-Modified to add support for X16R (Ravencoin). Work in progress... lots of room for improvement. Use `-a x16r`.
+Modified to add support for X16R (Ravencoin). Work in progress... lots of room for improvement. Use `-a x16r` and ' --num-fallback-threads n' where n is > 0.
 
 My interim  [Windows x64 builds](https://github.com/phasiclabs/ccminer-x16r/releases)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 Modified to add support for X16R (Ravencoin). Work in progress... lots of room for improvement. Use `-a x16r`.
 
-[Windows x64 builds](https://github.com/todd1251/ccminer/releases)
+My interim  [Windows x64 builds](https://github.com/phasiclabs/ccminer-x16r/releases)
+More official/better supported [Windows x64 builds](https://github.com/todd1251/ccminer/releases)
 
 BTC donation address: 1AJdfCpLWPNoAMDfHF1wD5y8VgKSSTHxPo (tpruvot)
 
 RVN donation address: RWoyvvT5exmbs937QfRavf4fxB5mvijG6R (penfold)
+
+RVN donation address: RE9hcu1LjVbzL1wzsnpnJP28B2x2Y4qc55 (phabit)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Modified to add support for X16R (Ravencoin). Work in progress... lots of room for improvement. Use `-a x16r`.
 
 My interim  [Windows x64 builds](https://github.com/phasiclabs/ccminer-x16r/releases)
+
 More official/better supported [Windows x64 builds](https://github.com/todd1251/ccminer/releases)
 
 BTC donation address: 1AJdfCpLWPNoAMDfHF1wD5y8VgKSSTHxPo (tpruvot)

--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -313,7 +313,7 @@ Options:\n\
       --cert=FILE       certificate for mining server using SSL\n\
   -x, --proxy=[PROTOCOL://]HOST[:PORT]  connect through a proxy\n\
   -t, --threads=N       number of miner threads (default: number of nVidia GPUs)\n\
-  -F, --num-fallback-threads    number of subthreads to use  (per mining thread) when falling back to the CPU (for X16R Algo).\n\
+      --num-fallback-threads    number of sub-threads to use  (per mining thread) when falling back to the CPU (for X16R Algo, valid range = 1-128. 8 is good for a 4 core cpu etc.)\n\
   -r, --retries=N       number of times to retry if a network call fails\n\
                           (default: retry indefinitely)\n\
   -R, --retry-pause=N   time to pause between retries, in seconds (default: 30)\n\
@@ -454,6 +454,7 @@ struct option options[] = {
 	{ "shares-limit", 1, NULL, 1009 },
 	{ "time-limit", 1, NULL, 1008 },
 	{ "threads", 1, NULL, 't' },
+	{ "num-fallback-threads", 1, NULL, 1201 },
 	{ "vote", 1, NULL, 1022 },
 	{ "trust-pool", 0, NULL, 1023 },
 	{ "timeout", 1, NULL, 'T' },
@@ -465,8 +466,8 @@ struct option options[] = {
 	{ "diff-multiplier", 1, NULL, 'm' },
 	{ "diff-factor", 1, NULL, 'f' },
 	{ "diff", 1, NULL, 'f' }, // compat
-	{ "num-fallback-threads", 1, NULL, 'F' },
 	{ 0, 0, 0, 0 }
+
 };
 
 static char const scrypt_usage[] = "\n\
@@ -3272,13 +3273,14 @@ void parse_arg(int key, char *arg)
 			show_usage_and_exit(1);
 		opt_n_threads = v;
 		break;
-	case 'F': // --num-fallback-threads
-		opt_n_cpu_fallback_threads = atof(arg);
+	case 1201: // --num-fallback-threads
+		v = atoi(arg);
 		
-		if(opt_n_cpu_fallback_threads < 1)
-		{
-			opt_n_cpu_fallback_threads = 1;
-		}
+		if (opt_n_cpu_fallback_threads < 1 || opt_n_cpu_fallback_threads > 128)	/* sanity check */
+			show_usage_and_exit(1);
+
+		opt_n_cpu_fallback_threads = v;
+	
 		break;
 	case 1022: // --vote
 		v = atoi(arg);

--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2010 Jeff Garzik
  * Copyright 2012-2014 pooler
  * Copyright 2014-2017 tpruvot
@@ -117,6 +117,7 @@ static json_t *opt_config;
 static const bool opt_time = true;
 volatile enum sha_algos opt_algo = ALGO_AUTO;
 int opt_n_threads = 0;
+int opt_n_cpu_fallback_threads = 1;
 int gpu_threads = 1;
 int64_t opt_affinity = -1L;
 int opt_priority = 0;
@@ -312,6 +313,7 @@ Options:\n\
       --cert=FILE       certificate for mining server using SSL\n\
   -x, --proxy=[PROTOCOL://]HOST[:PORT]  connect through a proxy\n\
   -t, --threads=N       number of miner threads (default: number of nVidia GPUs)\n\
+  -F, --num-fallback-threads    number of subthreads to use  (per mining thread) when falling back to the CPU (for X16R Algo).\n\
   -r, --retries=N       number of times to retry if a network call fails\n\
                           (default: retry indefinitely)\n\
   -R, --retry-pause=N   time to pause between retries, in seconds (default: 30)\n\
@@ -463,6 +465,7 @@ struct option options[] = {
 	{ "diff-multiplier", 1, NULL, 'm' },
 	{ "diff-factor", 1, NULL, 'f' },
 	{ "diff", 1, NULL, 'f' }, // compat
+	{ "num-fallback-threads", 1, NULL, 'F' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -3269,6 +3272,14 @@ void parse_arg(int key, char *arg)
 			show_usage_and_exit(1);
 		opt_n_threads = v;
 		break;
+	case 'F': // --num-fallback-threads
+		opt_n_cpu_fallback_threads = atof(arg);
+		
+		if(opt_n_cpu_fallback_threads < 1)
+		{
+			opt_n_cpu_fallback_threads = 1;
+		}
+		break;
 	case 1022: // --vote
 		v = atoi(arg);
 		if (v < 0 || v > 8192)	/* sanity check */
@@ -3667,7 +3678,6 @@ void parse_arg(int key, char *arg)
 			show_usage_and_exit(1);
 		opt_difficulty = 1.0/d;
 		break;
-
 	/* PER POOL CONFIG OPTIONS */
 
 	case 1100: /* pool name */

--- a/miner.h
+++ b/miner.h
@@ -528,6 +528,7 @@ extern bool opt_protocol;
 extern bool opt_showdiff;
 extern bool opt_tracegpu;
 extern int opt_n_threads;
+extern int opt_n_cpu_fallback_threads;
 extern int active_gpus;
 extern int gpu_threads;
 extern int opt_timeout;

--- a/x16r/x16r.cu
+++ b/x16r/x16r.cu
@@ -67,7 +67,32 @@ static const char *hash_names[X16R_HASH_COUNT] =
     "sha512",
 };
 
+typedef struct 
+{
+    int                     id;
+    pthread_t               thread;
+    pthread_cond_t          cond;
+    pthread_mutex_t         mutex;
+    int                     thr_id;
+    uint32_t                joboffset;
+    uint32_t                jobcount;
+    uint32_t                nonce_begin;
+    uint32_t                endiandata[20];
+    int                     hash_selection;
+	bool					exit_thread;
+
+    sph_simd512_context     ctx_simd;       //9
+    sph_echo512_context     ctx_echo;       //A
+    sph_hamsi512_context    ctx_hamsi;      //B
+    sph_fugue512_context    ctx_fugue;      //C
+    sph_shabal512_context   ctx_shabal;     //D
+    sph_sha512_context      ctx_sha512;     //F
+
+} subthread_t;
+
 static uint32_t *d_hash[MAX_GPUS];
+static uint32_t *h_hash[MAX_GPUS];
+static subthread_t *sub_threads[MAX_GPUS];
 
 // CPU HASH
 inline int get_hash_selection(const uint8_t *prev_block_hash, int index)
@@ -214,70 +239,169 @@ extern "C" void x16rhash(void *output, const void *input)
 #define _DEBUG_PREFIX "x16r"
 #include "cuda_debug.cuh"
 
+static void *scanhash_cpufallback_thread(void *userdata)
+{
+    subthread_t& subthread = *((subthread_t*)userdata);
+
+    while (1)
+    {
+        pthread_mutex_lock(&subthread.mutex);
+        
+        while (!subthread.jobcount)
+        {
+            pthread_cond_wait(&subthread.cond, &subthread.mutex);
+        }
+
+		if (subthread.exit_thread)
+		{
+			pthread_mutex_unlock(&subthread.mutex);
+
+			break;
+		}
+
+        if (opt_debug)
+        {
+            gpulog(LOG_DEBUG, subthread.thr_id, "subthread %d : running jobs %u->%u.", subthread.id, subthread.joboffset, subthread.joboffset + subthread.jobcount);
+        }
+
+        for (uint32_t i = subthread.joboffset; i < subthread.joboffset + subthread.jobcount; i++)
+        {
+            uint32_t* target_hash = &h_hash[subthread.thr_id][16 * i];
+            be32enc(&subthread.endiandata[19], subthread.nonce_begin + i);
+            
+            switch (subthread.hash_selection)
+            {
+                case X16R_SIMD:
+                    sph_simd512_init(&subthread.ctx_simd);
+                    sph_simd512(&subthread.ctx_simd, subthread.endiandata, 80);
+                    sph_simd512_close(&subthread.ctx_simd, target_hash);
+                    break;
+                case X16R_ECHO:
+                    sph_echo512_init(&subthread.ctx_echo);
+                    sph_echo512(&subthread.ctx_echo, subthread.endiandata, 80);
+                    sph_echo512_close(&subthread.ctx_echo, target_hash);
+                    break;
+                case X16R_HAMSI:
+                    sph_hamsi512_init(&subthread.ctx_hamsi);
+                    sph_hamsi512(&subthread.ctx_hamsi, subthread.endiandata, 80);
+                    sph_hamsi512_close(&subthread.ctx_hamsi, target_hash);
+                    break;
+                case X16R_FUGUE:
+                    sph_fugue512_init(&subthread.ctx_fugue);
+                    sph_fugue512(&subthread.ctx_fugue, subthread.endiandata, 80);
+                    sph_fugue512_close(&subthread.ctx_fugue, target_hash);
+                    break;
+                case X16R_SHABAL:
+                    sph_shabal512_init(&subthread.ctx_shabal);
+                    sph_shabal512(&subthread.ctx_shabal, subthread.endiandata, 80);
+                    sph_shabal512_close(&subthread.ctx_shabal, target_hash);
+                    break;
+                case X16R_SHA512:
+                    sph_sha512_init(&subthread.ctx_sha512);
+                    sph_sha512(&subthread.ctx_sha512, subthread.endiandata, 80);
+                    sph_sha512_close(&subthread.ctx_sha512, target_hash);
+                break;
+                default:
+                    gpulog(LOG_ERR, subthread.thr_id, "hash selection not valid for cpu multithreading: %d (this should never happen!)", &subthread.hash_selection);
+                    break;
+            }   
+        }
+
+        cudaMemcpy(d_hash[subthread.thr_id] + (subthread.joboffset * 16), h_hash[subthread.thr_id] + (subthread.joboffset * 16), (subthread.jobcount * 16) *sizeof(uint32_t), cudaMemcpyHostToDevice);
+    
+        if (opt_debug)
+        {
+            gpulog(LOG_DEBUG, subthread.thr_id, "subthread %d finished.");
+        }
+
+        subthread.jobcount = 0;
+
+        pthread_mutex_unlock(&subthread.mutex);
+    }
+
+	return NULL;
+}
+
+
 static bool init[MAX_GPUS] = { 0 };
 
 extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, unsigned long *hashes_done)
 {
-	uint32_t *pdata = work->data;
-	uint32_t *ptarget = work->target;
-	const uint32_t first_nonce = pdata[19];
-	int intensity = (device_sm[device_map[thr_id]] >= 500 && !is_windows()) ? 20 : 19;
-	uint32_t throughput = cuda_default_throughput(thr_id, 1U << intensity); // 19=256*256*8;
+    uint32_t *pdata = work->data;
+    uint32_t *ptarget = work->target;
+    const uint32_t first_nonce = pdata[19];
+    int intensity = (device_sm[device_map[thr_id]] >= 500 && !is_windows()) ? 20 : 19;
+    uint32_t throughput = cuda_default_throughput(thr_id, 1U << intensity); // 19=256*256*8;
 
-    // FIXME: CPU fallback for unimplemented first round algorithms
-    uint32_t _ALIGN(64) h_hash[16];
-    sph_simd512_context      ctx_simd;       //9
-    sph_echo512_context      ctx_echo;       //A
-    sph_hamsi512_context     ctx_hamsi;      //B
-    sph_fugue512_context     ctx_fugue;      //C
-    sph_shabal512_context    ctx_shabal;     //D
-    sph_sha512_context       ctx_sha512;     //F
-
-	if (opt_benchmark)
-	{
-		ptarget[7] = 0x5;
+    if (opt_benchmark)
+    {
+        ptarget[7] = 0x5;
     }
 
-	if (!init[thr_id])
-	{
-		cudaSetDevice(device_map[thr_id]);
-		if (opt_cudaschedule == -1 && gpu_threads == 1)
-		{
-			cudaDeviceReset();
-			// reduce cpu usage
-			cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
-			CUDA_LOG_ERROR();
-		}
-		gpulog(LOG_INFO, thr_id, "Intensity set to %g, %u cuda threads", throughput2intensity(throughput), throughput);
+    int num_sub_threads = opt_n_cpu_fallback_threads;
+            
+    if (!init[thr_id])
+    {
+        cudaSetDevice(device_map[thr_id]);
+        if (opt_cudaschedule == -1 && gpu_threads == 1)
+        {
+            cudaDeviceReset();
+            // reduce cpu usage
+            cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+            CUDA_LOG_ERROR();
+        }
+        gpulog(LOG_INFO, thr_id, "Intensity set to %g, %u cuda threads", throughput2intensity(throughput), throughput);
 
-		quark_blake512_cpu_init(thr_id, throughput);
-		quark_blake512_cpu_init(thr_id, throughput);
-		quark_bmw512_cpu_init(thr_id, throughput);
-		quark_groestl512_cpu_init(thr_id, throughput);
-		quark_jh512_cpu_init(thr_id, throughput);
-		quark_keccak512_cpu_init(thr_id, throughput);
-		quark_skein512_cpu_init(thr_id, throughput);
-		qubit_luffa512_cpu_init(thr_id, throughput);
-		x11_luffa512_cpu_init(thr_id, throughput);
-		x11_cubehash512_cpu_init(thr_id, throughput);
-		x11_shavite512_cpu_init(thr_id, throughput);
-		x11_simd512_cpu_init(thr_id, throughput);
-		x11_echo512_cpu_init(thr_id, throughput);
-		x13_hamsi512_cpu_init(thr_id, throughput);
-		x13_fugue512_cpu_init(thr_id, throughput);
-		x14_shabal512_cpu_init(thr_id, throughput);
+        quark_blake512_cpu_init(thr_id, throughput);
+        quark_blake512_cpu_init(thr_id, throughput);
+        quark_bmw512_cpu_init(thr_id, throughput);
+        quark_groestl512_cpu_init(thr_id, throughput);
+        quark_jh512_cpu_init(thr_id, throughput);
+        quark_keccak512_cpu_init(thr_id, throughput);
+        quark_skein512_cpu_init(thr_id, throughput);
+        qubit_luffa512_cpu_init(thr_id, throughput);
+        x11_luffa512_cpu_init(thr_id, throughput);
+        x11_cubehash512_cpu_init(thr_id, throughput);
+        x11_shavite512_cpu_init(thr_id, throughput);
+        x11_simd512_cpu_init(thr_id, throughput);
+        x11_echo512_cpu_init(thr_id, throughput);
+        x13_hamsi512_cpu_init(thr_id, throughput);
+        x13_fugue512_cpu_init(thr_id, throughput);
+        x14_shabal512_cpu_init(thr_id, throughput);
         whirlpool512_init_sm3(thr_id, throughput, 0);
-		x15_whirlpool_cpu_init(thr_id, throughput, 0);
-		x17_sha512_cpu_init(thr_id, throughput);
+        x15_whirlpool_cpu_init(thr_id, throughput, 0);
+        x17_sha512_cpu_init(thr_id, throughput);
 
-		CUDA_CALL_OR_RET_X(cudaMalloc(&d_hash[thr_id], (size_t) 64 * throughput), 0);
+        CUDA_CALL_OR_RET_X(cudaMalloc(&d_hash[thr_id], (size_t) 64 * throughput), 0);
 
-		cuda_check_cpu_init(thr_id, throughput);
+        h_hash[thr_id] = (uint32_t*)malloc((size_t)64 * throughput);
+        
+        if (opt_debug)
+        {
+            gpulog(LOG_DEBUG, thr_id, "Num CPU-Fallback subthreads  = %d", num_sub_threads);
+        }
 
-		init[thr_id] = true;
-	}
+        for (int i = 0; i < num_sub_threads; ++i)
+        {
+            subthread_t& sub_thr = sub_threads[thr_id][i];
+
+			sub_thr.jobcount = 0;
+
+            pthread_mutex_init(&sub_thr.mutex, NULL);
+            pthread_cond_init(&sub_thr.cond, NULL);
+    
+            pthread_create(&sub_thr.thread, NULL, scanhash_cpufallback_thread, &sub_thr);
+
+			sub_thr.thr_id = thr_id;
+        }
+        
+        cuda_check_cpu_init(thr_id, throughput);
+
+        init[thr_id] = true;
+    }
 
     uint32_t endiandata[20];
+    
     for (int i = 0; i < 20; i++)
     {
         be32enc(&endiandata[i], pdata[i]);
@@ -314,11 +438,13 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
         );
     }
 
+    bool cpuFallback = false;
+    
     switch (hash_selection[0])
     {
         case X16R_BLAKE:
-	        quark_blake512_cpu_setBlock_80(thr_id, endiandata);
-	        break;
+            quark_blake512_cpu_setBlock_80(thr_id, endiandata);
+            break;
         case X16R_BMW:
             quark_bmw512_cpu_setBlock_80(endiandata);
             break;
@@ -326,8 +452,8 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             groestl512_setBlock_80(thr_id, endiandata);
             break;
         case X16R_JH:
-	        jh512_setBlock_80(thr_id, endiandata);
-	        break;
+            jh512_setBlock_80(thr_id, endiandata);
+            break;
         case X16R_KECCAK:
             keccak512_setBlock_80(thr_id, endiandata);
             break;
@@ -344,30 +470,35 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             x11_shavite512_setBlock_80(endiandata);
             break;
         case X16R_SIMD:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: simd512/80 (falling back on CPU for first round)");
             }
             break;
         case X16R_ECHO:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: echo512/80 (falling back on CPU for first round)");
             }
             break;
         case X16R_HAMSI:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: hamsi512/80 (falling back on CPU for first round)");
             }
             break;
         case X16R_FUGUE:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: fugue512/80 (falling back on CPU for first round)");
             }
             break;
         case X16R_SHABAL:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: shabal512/80 (falling back on CPU for first round)");
@@ -377,6 +508,7 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             whirlpool512_setBlock_80_sm3((void*)endiandata, ptarget);
             break;
         case X16R_SHA512:
+            cpuFallback = true;
             if (opt_debug)
             {
                 gpulog(LOG_DEBUG, thr_id, "Not yet implemented: sha512/80 (falling back on CPU for first round)");
@@ -387,14 +519,16 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             break;
     }
 
-	cuda_check_cpu_setTarget(ptarget);
+    cuda_check_cpu_setTarget(ptarget);
 
-	do
-	{
+    do
+    {
         int order = 0;
 
-		switch (hash_selection[0])
-		{
+        memset(h_hash[thr_id], 0, (size_t)64 * throughput);
+
+        switch (hash_selection[0])
+        {
             case X16R_BLAKE:
                 quark_blake512_cpu_hash_80(thr_id, throughput, pdata[19], d_hash[thr_id]); order++;
                 break;
@@ -422,78 +556,79 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             case X16R_SHAVITE:
                 x11_shavite512_cpu_hash_80(thr_id, throughput, pdata[19], d_hash[thr_id], order++);
                 break;
-            case X16R_SIMD:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_simd512_init(&ctx_simd);
-                    sph_simd512(&ctx_simd, endiandata, 80);
-                    sph_simd512_close(&ctx_simd, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-                break;
-            case X16R_ECHO:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_echo512_init(&ctx_echo);
-                    sph_echo512(&ctx_echo, endiandata, 80);
-                    sph_echo512_close(&ctx_echo, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-                break;
-            case X16R_HAMSI:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_hamsi512_init(&ctx_hamsi);
-                    sph_hamsi512(&ctx_hamsi, endiandata, 80);
-                    sph_hamsi512_close(&ctx_hamsi, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-                break;
-            case X16R_FUGUE:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_fugue512_init(&ctx_fugue);
-                    sph_fugue512(&ctx_fugue, endiandata, 80);
-                    sph_fugue512_close(&ctx_fugue, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-                break;
-            case X16R_SHABAL:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_shabal512_init(&ctx_shabal);
-                    sph_shabal512(&ctx_shabal, endiandata, 80);
-                    sph_shabal512_close(&ctx_shabal, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-                break;
             case X16R_WHIRLPOOL:
-		        whirlpool512_hash_80_sm3(thr_id, throughput, pdata[19], d_hash[thr_id]); order++;
+                whirlpool512_hash_80_sm3(thr_id, throughput, pdata[19], d_hash[thr_id]); order++;
                 break;
+            case X16R_SIMD:
+            case X16R_ECHO:
+            case X16R_HAMSI:
+            case X16R_FUGUE:
+            case X16R_SHABAL:
             case X16R_SHA512:
-                for (int i = 0; i < throughput; i++)
-                {
-                    be32enc(&endiandata[19], pdata[19] + i);
-                    sph_sha512_init(&ctx_sha512);
-                    sph_sha512(&ctx_sha512, endiandata, 80);
-                    sph_sha512_close(&ctx_sha512, h_hash);
-                    cudaMemcpy(d_hash[thr_id] + (16 * i), h_hash, 16 * sizeof(uint32_t), cudaMemcpyHostToDevice);
-                }
-		        break;
+                // Now handled on separate threads.
+                break;
             default:
                 gpulog(LOG_ERR, thr_id, "Round %d unknown hash selection: %d (this should never happen!)", 0, hash_selection[0]);
                 break;
-		}
+        }
 
-        be32enc(&endiandata[19], pdata[19]);
+		// FIXME: CPU fallback for unimplemented first round algorithms
+        if (cpuFallback)
+        {   
+            int num = (int)(throughput / num_sub_threads);
+            int extra = throughput - (num * num_sub_threads);
+
+            int start = 0;
+
+            if (opt_debug)
+            {
+                gpulog(LOG_DEBUG, thr_id, "Waking CPU-Fallback subthreads");
+            }
+
+            for (int i = 0; i < num_sub_threads; ++i)
+            {
+                subthread_t& sub_thr = sub_threads[thr_id][i];
+
+                pthread_mutex_lock(&sub_thr.mutex);
+    
+                sub_thr.hash_selection = hash_selection[0];
+                
+                memcpy(sub_thr.endiandata, endiandata, sizeof(endiandata));
+
+                sub_thr.nonce_begin = pdata[19];
+                sub_thr.joboffset = start;
+
+                sub_thr.jobcount = num;
+
+                if (i < extra)
+                {
+                    sub_thr.jobcount++;
+                }
+
+                start += sub_thr.jobcount;
+
+                pthread_cond_signal(&sub_thr.cond);
+                pthread_mutex_unlock(&sub_thr.mutex);
+            }
+
+            // Wait for all sub-threads to complete :
+
+            for (int i = 0; i < num_sub_threads; ++i)
+            {
+                subthread_t& sub_thr = sub_threads[thr_id][i];
+
+                pthread_mutex_lock(&sub_thr.mutex);
+                pthread_mutex_unlock(&sub_thr.mutex);
+            }
+
+            if (opt_debug)
+            {
+                gpulog(LOG_DEBUG, thr_id, "CPU-Fallback subthreads finished");
+            }
+        }
 
         for (int i = 1; i < X16R_HASH_COUNT; i++)
-		{
+        {
             switch (hash_selection[i])
             {
                 case X16R_BLAKE:
@@ -590,41 +725,60 @@ extern "C" int scanhash_x16r(int thr_id, struct work* work, uint32_t max_nonce, 
             }
         }
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce)
-		{
-			pdata[19] = max_nonce;
-			break;
-		}
-		pdata[19] += throughput;
+        if ((uint64_t) throughput + pdata[19] >= max_nonce)
+        {
+            pdata[19] = max_nonce;
+            break;
+        }
+        pdata[19] += throughput;
 
-	}
-	while (!work_restart[thr_id].restart);
+    }
+    while (!work_restart[thr_id].restart);
 
-	*hashes_done = pdata[19] - first_nonce;
-	return 0;
+    *hashes_done = pdata[19] - first_nonce;
+    return 0;
 }
 
 // cleanup
 extern "C" void free_x16r(int thr_id)
 {
-	if (!init[thr_id])
-	{
-		return;
+    if (!init[thr_id])
+    {
+        return;
     }
 
-	cudaThreadSynchronize();
+    cudaThreadSynchronize();
 
-	cudaFree(d_hash[thr_id]);
+	int num_sub_threads = opt_n_cpu_fallback_threads;
 
-	quark_blake512_cpu_free(thr_id);
+	for (int i = 0; i < num_sub_threads; ++i)
+	{
+		subthread_t& sub_thr = sub_threads[thr_id][i];
+
+		pthread_mutex_lock(&sub_thr.mutex);
+		pthread_cond_signal(&sub_thr.cond);
+		pthread_mutex_unlock(&sub_thr.mutex);
+
+		void* ret;
+
+		pthread_join(sub_thr.thread, &ret);
+		
+   		pthread_mutex_destroy(&sub_thr.mutex);
+		pthread_cond_destroy(&sub_thr.cond);
+	}
+
+    cudaFree(d_hash[thr_id]);
+	free(h_hash[thr_id]);
+	
+    quark_blake512_cpu_free(thr_id);
     quark_groestl512_cpu_free(thr_id);
     x11_simd512_cpu_free(thr_id);
     x13_fugue512_cpu_free(thr_id);
     whirlpool512_free_sm3(thr_id);
     x15_whirlpool_cpu_free(thr_id);
 
-	cuda_check_cpu_free(thr_id);
-	init[thr_id] = false;
+    cuda_check_cpu_free(thr_id);
+    init[thr_id] = false;
 
-	cudaDeviceSynchronize();
+    cudaDeviceSynchronize();
 }

--- a/x16r/x16r.cu
+++ b/x16r/x16r.cu
@@ -71,8 +71,8 @@ typedef struct
 {
     int                     id;
     pthread_t               thread;
-    pthread_cond_t          cond = PTHREAD_COND_INITIALIZER;
-    pthread_mutex_t         mutex = PTHREAD_MUTEX_INITIALIZER;
+    pthread_cond_t          cond;
+    pthread_mutex_t         mutex;
     int                     thr_id;
     uint32_t                joboffset;
     uint32_t                jobcount;


### PR DESCRIPTION
Hiya - I've added multi-threading to X16R CPU-Fallback hashing. 
It significantly improves hashrate for 'home user' setups, with 1 CPU and 1 GPU. 
Won't be so good for mining rigs with 1 CPU and many GPUs.

Thread count can be set with --num-fallback-threads (eg. --num-fallback-threads 8 for a 4 core, 8 thead CPU).

Feel free to merge it with your fork if you like - I'm mining away with it already! :D

This can all be removed again once all algos are fully supported in GPU.